### PR TITLE
Reinstall converted files

### DIFF
--- a/tox_py_backwards.py
+++ b/tox_py_backwards.py
@@ -17,6 +17,7 @@ mkdir .tox/py_backwards/
 cp -a * .tox/py_backwards/
 py-backwards -i .tox/py_backwards/ -o .tox/py_backwards/ -t $VERSION
 cd .tox/py_backwards/
+pip install -I .
 {}
 rm -rf .tox/py_backwards/
 '''


### PR DESCRIPTION
In python 3.5 and tox 2.7, it used original (not converted) files for test.
So it needs to reinstall package.